### PR TITLE
prevent .nfw_score from interfering with pointer events

### DIFF
--- a/netfweb/content.css
+++ b/netfweb/content.css
@@ -20,6 +20,7 @@ div.nfw_score{
     font-weight: bold;
     text-align: center;
     z-index:1;
+    pointer-events: none;
 }
 
 span.nfw_score_bob {


### PR DESCRIPTION
Pointer events on the .nfw_score elements cause the Netflix hover-over preview to exit.  This fix tested on Firefox.