### PR TITLE
Make borders of circles (brightly) coloured too

### DIFF
--- a/netfweb/content.css
+++ b/netfweb/content.css
@@ -25,18 +25,22 @@ div.nfw_score{
 
 div.nfw_circle_red{
     background: rgba(100,0,0,0.7);
+    border-color: #FF0000;
 }
 
 div.nfw_circle_green{
     background: rgba(0,100,0,0.7);
+    border-color: #00FF00;
 }
 
 div.nfw_circle_yellow{
     background: rgba(100,100,0,0.7);
+    border-color: #FFFF00;
 }
 
 div.nfw_circle_orange{
     background: rgba(100,70,0,0.7);
+    border-color: #FF9900;
 }
 
 


### PR DESCRIPTION
I'd actually forgotten I'd ticked coloured circles because the colouring is so subtle I didn't really notice it. This PR makes the circle borders brightly coloured so it's easy to scan a page of titles and pick out the best rated.