### PR TITLE
25 fix filmweb

### DIFF
--- a/netfweb/info.html
+++ b/netfweb/info.html
@@ -226,7 +226,7 @@
               <li><input id="rotten_tomatoes_check" class="nfw_checkbox" type="checkbox" checked="checked"> Rotten Tomatoes</li>
               <li><input id="film_affinity_check" class="nfw_checkbox" type="checkbox" checked="checked"> FilmAffinity </li>
               <li><input id="metacritic_check" class="nfw_checkbox" type="checkbox" checked="checked"> Metacritic </li>        
-              <li><input id="filmweb_check" class="nfw_checkbox" type="checkbox"> Filmweb.pl </li>
+              <li><input id="filmweb_check" class="nfw_checkbox" type="checkbox" checked="checked"> Filmweb.pl </li>
               <li><input id="trak_tv_check" class="nfw_checkbox" type="checkbox" checked="checked"> Trakt TV </li>			  
              </ul>
 

--- a/netfweb/info.html
+++ b/netfweb/info.html
@@ -226,7 +226,7 @@
               <li><input id="rotten_tomatoes_check" class="nfw_checkbox" type="checkbox" checked="checked"> Rotten Tomatoes</li>
               <li><input id="film_affinity_check" class="nfw_checkbox" type="checkbox" checked="checked"> FilmAffinity </li>
               <li><input id="metacritic_check" class="nfw_checkbox" type="checkbox" checked="checked"> Metacritic </li>        
-              <li><input id="filmweb_check" class="nfw_checkbox" type="checkbox" checked="checked"> Filmweb.pl </li>
+              <li><input id="filmweb_check" class="nfw_checkbox" type="checkbox"> Filmweb.pl </li>
               <li><input id="trak_tv_check" class="nfw_checkbox" type="checkbox" checked="checked"> Trakt TV </li>			  
              </ul>
 
@@ -269,6 +269,8 @@
 
         <div class='desc'>
             <h3>changelog</h3><a name='changelog'></a>
+            <h4> 1.1.0</h4>
+            <p>TraktTv ratings added thanks to @Jose-Nogueira! Fixed problem with FilmWeb ratings.</p>
             <h4> 1.0.1</h4>
             <p>Once more, thanks to @elchenberg, we've got FilmAffinity rating available!</p>
             <h4> 1.0.0</h4>

--- a/netfweb/manifest.json
+++ b/netfweb/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Film scores for Netflix",
   "short_name": "netfweb",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Enriches Netflix site with a ratings based on the scores from most popular review websites.",
   "permissions": [
     "https://www.netflix.com/",
@@ -36,7 +36,7 @@
   }],
 
   "background": {
-    "scripts": ["jquery.js", "map_tmdb.js", "map_imdb.js", "map_metacritic.js", "map_filmweb.js", "map_trakttv.js", "background.js"],
+    "scripts": ["jquery.js", "map_tmdb.js", "map_imdb.js", "map_metacritic.js", "map_trakttv.js", "background.js"],
     "persistent": true
   }
 

--- a/netfweb/manifest.json
+++ b/netfweb/manifest.json
@@ -15,7 +15,7 @@
     "https://www.lina.pl/",
     "https://www.rottentomatoes.com/",
     "https://www.filmaffinity.com/",
-	  "https://trakt.tv/",
+    "https://trakt.tv/",
     "storage",
     "tabs"
    ],


### PR DESCRIPTION
In order to bring back the Filmweb ratings, the support for cached mapping between Netflix Ids and FIlmweb URL has been removed. 

Solves #25